### PR TITLE
Added missing bib entries to Borrowing_references

### DIFF
--- a/raw/Borrowing_references.bib
+++ b/raw/Borrowing_references.bib
@@ -1,4 +1,73 @@
 
+@book{NES,
+	address = {Helsinki},
+	title = {Nykysuomen etymologinen sanakirja},
+	publisher = {WSOY},
+	author = {Häkkinen, Kaisa},
+	year = {2004}
+}
+
+@incollection{Aikio2004a,
+	address = {Helsinki},
+	series = {Mémoires de la {Société} {Néophilologique} de {Helsinki}},
+	title = {An essay on {Saami} ethnolinguistic prehistory},
+	number = {63},
+	booktitle = {Etymologie, {Entlehnungen} und {Entwicklungen}: {Festschrift} für {Jorma} {Koivulehto} zum 70. {Geburtstag}},
+	author = {Aikio, Ante},
+	editor = {Hyvärinen, Irma and Kallio, Petri and Korhonen, Jarmo},
+	year = {2004},
+	pages = {5--34}
+}
+
+@incollection{Aikio2004,
+	address = {Helsinki},
+	series = {Mémoires de la {Société} néophilologique de {Helsinki}},
+	title = {An {Essay} on {Substrate} {Studies} and the {Origin} of {Saami}},
+	volume = {63},
+	booktitle = {Etymologie, {Entlehnungen} und {Entwicklungen}: {Festschrift} für {Jorma} {Koivulehto} zum 70. {Geburtstag}},
+	publisher = {Société néophilologique},
+	author = {Aikio, Ante},
+	editor = {Hyvärinen, Irma and Kallio, Petri and Korhonen, Jarmo and Kolehmainen, Leena},
+	year = {2004},
+	pages = {5--34}
+}
+
+@incollection{Aikio2012,
+	address = {Helsinki},
+	title = {An essay on {Saami} ethnolinguistic prehistory},
+	booktitle = {A linguistic map of prehistoric northern {Europe}},
+	publisher = {Suomalais-ugrilaisen seuran toimituksia},
+	author = {Aikio, Ante},
+	editor = {Grünthal, Riho and Kallio, Petri},
+	year = {2012},
+	pages = {63--117}
+}
+
+
+@article{Koivulehto2000,
+	title = {Reflexe des urbaltischen ā in baltischen {Lehnwörtern} des {Ostseefinnischen}},
+	volume = {8},
+	journal = {Linguistica baltica. International Journal of Baltic Linguistics.},
+	author = {Koivulehto, Jorma},
+	year = {2000}
+}
+
+@article{Katz1983,
+	title = {Zu idg. *mrtó-},
+	volume = {29},
+	journal = {Die Sprache},
+	author = {Katz, Hartmut},
+	year = {1983},
+	pages = {174--177}
+}
+
+@book{Rédei1968,
+	address = {Budapest},
+	title = {Permjakisches {Wörterverzeichnis} aus dem {Jahre} 1833 auf {Grund} der {Aufzeichnungen} {F}.{A}. {Wolegows}},
+	author = {Rédei, Károly},
+	year = {1968},
+	annote = {U}
+}
 @book{Zaicz2006,
 address = {Budapest},
 edition = {1},


### PR DESCRIPTION
After discussing with the other collaborators, it seems to be clearer for us if we could only have one bib file for the Borrowing_references. Therefore, I have added the entries from "missing" to the bib. 