### PR TITLE
Added a sentence for including the DOI

### DIFF
--- a/uralex_documentation.md
+++ b/uralex_documentation.md
@@ -13,6 +13,8 @@ and
 
 Syrjänen, Kaj; Maurits, Luke; Leino, Unni; Honkola, Terhi; Rota, Jadranka & Vesakoski, Outi. (submitted manuscript). “Crouching TIGER, Hidden Structure: Exploring the nature of linguistic data using TIGER values.”
 
+Also include the DOI provided for UraLex 2.0 in this release.
+
 
 ## Overview
 


### PR DESCRIPTION
This Readme citing information now includes the DOI suggestion so it matches the Landing Page Readme